### PR TITLE
Fix pause in turn

### DIFF
--- a/game_plugins/hase_und_igel_new/server/sc/plugin2018/Game.java
+++ b/game_plugins/hase_und_igel_new/server/sc/plugin2018/Game.java
@@ -91,7 +91,6 @@ public class Game extends RoundBasedGameInstance<Player>
    * In this game, a new round begins when both players made one move. The order
    * in which the players make their move may change.
    */
-  @Override
   protected boolean increaseTurnIfNecessary(Player nextPlayer) {
     return getGameState().getTurn() % 2 == 0;
   }

--- a/game_server/src/sc/server/Lobby.java
+++ b/game_server/src/sc/server/Lobby.java
@@ -163,6 +163,8 @@ public class Lobby implements IClientListener
           CancelRequest cancel = (CancelRequest) packet;
           GameRoom room = this.gameManager.findRoom(cancel.roomId);
           room.cancel();
+          // TODO check whether all client receive game over message
+          this.gameManager.getGames().remove(room);
         }
 			}
 			else if (packet instanceof TestModeRequest) {

--- a/game_server/src/sc/server/Lobby.java
+++ b/game_server/src/sc/server/Lobby.java
@@ -152,9 +152,9 @@ public class Lobby implements IClientListener
 			else if (packet instanceof StepRequest)
 			{
 			  if (source.isAdministrator()) {
-          StepRequest pause = (StepRequest) packet;
-          GameRoom room = this.gameManager.findRoom(pause.roomId);
-          room.step(pause.forced);
+          StepRequest stepRequest = (StepRequest) packet;
+          GameRoom room = this.gameManager.findRoom(stepRequest.roomId);
+          room.step(stepRequest.forced);
         }
 			}
 			else if (packet instanceof CancelRequest)

--- a/game_server/src/sc/server/Lobby.java
+++ b/game_server/src/sc/server/Lobby.java
@@ -151,6 +151,9 @@ public class Lobby implements IClientListener
 			}
 			else if (packet instanceof StepRequest)
 			{
+				/*
+				It is not checked whether there is a prior pending StepRequest
+				 */
 			  if (source.isAdministrator()) {
           StepRequest stepRequest = (StepRequest) packet;
           GameRoom room = this.gameManager.findRoom(stepRequest.roomId);

--- a/game_server/src/sc/server/gaming/GameRoom.java
+++ b/game_server/src/sc/server/gaming/GameRoom.java
@@ -595,7 +595,6 @@ public class GameRoom implements IGameListener
 	}
 
   /**
-	 * TODO use Optional here
    * Pause or un-pause a game
    * @param pause true if game is to be paused
    */
@@ -618,7 +617,7 @@ public class GameRoom implements IGameListener
 		this.paused = pause;
 		RoundBasedGameInstance<SimplePlayer> pausableGame = (RoundBasedGameInstance<SimplePlayer>) this.game;
 		// pause game after current turn has finished
-		pausableGame.setPauseMode(Optional.of(((RoundBasedGameInstance<SimplePlayer>) this.game).getRound() + 1));
+		pausableGame.setPauseMode(pause);
 
 		// continue execution
 		if (!isPaused())
@@ -655,7 +654,7 @@ public class GameRoom implements IGameListener
 		if (isPaused())
 		{
 			logger.info("Stepping.");
-			((RoundBasedGameInstance<SimplePlayer>) this.game).afterPause(); // XXX
+			((RoundBasedGameInstance<SimplePlayer>) this.game).afterPause();
 		}
 		else
 		{
@@ -727,7 +726,8 @@ public class GameRoom implements IGameListener
 	}
 
 	/**
-	 * Return whether or not the game is paused
+	 * Return whether or not the game is paused or will be paused in the next turn.
+	 * Refer to {@link RoundBasedGameInstance#isPaused()} for the current value
 	 * @return true, if game is paused
 	 */
 	public boolean isPaused()

--- a/game_server/src/sc/server/gaming/GameRoom.java
+++ b/game_server/src/sc/server/gaming/GameRoom.java
@@ -1,12 +1,7 @@
 package sc.server.gaming;
 
 import java.io.*;
-import java.util.ArrayList;
-import java.util.Collection;
-import java.util.Collections;
-import java.util.LinkedList;
-import java.util.List;
-import java.util.Map;
+import java.util.*;
 
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
@@ -600,6 +595,7 @@ public class GameRoom implements IGameListener
 	}
 
   /**
+	 * TODO use Optional here
    * Pause or un-pause a game
    * @param pause true if game is to be paused
    */
@@ -620,8 +616,9 @@ public class GameRoom implements IGameListener
 
 		logger.info("Switching PAUSE from {} to {}.", isPaused(), pause);
 		this.paused = pause;
-		RoundBasedGameInstance<SimplePlayer> pausableGame = (RoundBasedGameInstance<SimplePlayer>) this.game; // XXX
-		pausableGame.setPauseMode(isPaused());
+		RoundBasedGameInstance<SimplePlayer> pausableGame = (RoundBasedGameInstance<SimplePlayer>) this.game;
+		// pause game after current turn has finished
+		pausableGame.setPauseMode(Optional.of(((RoundBasedGameInstance<SimplePlayer>) this.game).getRound() + 1));
 
 		// continue execution
 		if (!isPaused())

--- a/game_server/test/sc/protocol/requests/RequestTest.java
+++ b/game_server/test/sc/protocol/requests/RequestTest.java
@@ -3,6 +3,8 @@ package sc.protocol.requests;
 import org.junit.Assert;
 import org.junit.Before;
 import org.junit.Test;
+import sc.api.plugins.exceptions.GameLogicException;
+import sc.framework.plugins.RoundBasedGameInstance;
 import sc.framework.plugins.SimplePlayer;
 import sc.networking.clients.LobbyClient;
 import sc.protocol.responses.PrepareGameProtocolMessage;
@@ -141,6 +143,61 @@ public class RequestTest extends RealServerTest{
   }
 
   @Test
+  public void stepRequestException() {
+    LobbyClient admin = player1;
+    LobbyClient player1 = this.player2;
+    LobbyClient player2 = this.player3;
+    PlayerListener p1Listener = new PlayerListener();
+    PlayerListener p2Listener = new PlayerListener();
+
+    // Make player1 Admin and prepare a game in paused mode
+    admin.authenticate(PASSWORD);
+    TestLobbyClientListener listener = new TestLobbyClientListener();
+    admin.addListener(listener);
+
+    player1.joinRoomRequest(TestPlugin.TEST_PLUGIN_UUID);
+    TestHelper.waitMills(500);
+
+    // Room was created
+    GameRoom room = lobby.getGameManager().getGames().iterator().next();
+    SimplePlayer sp1 = room.getSlots().get(0).getRole().getPlayer();
+    sp1.addPlayerListener(p1Listener);
+    admin.send(new PauseGameRequest(room.getId(),true));
+    admin.observe(room.getId());
+
+    // Wait for admin
+    TestHelper.waitUntilTrue(()->listener.observedReceived, 2000);
+
+
+    player2.joinRoomRequest(TestPlugin.TEST_PLUGIN_UUID);
+    TestHelper.waitMills(500);
+    room.getSlots().get(1).getRole().getPlayer().addPlayerListener(p2Listener);
+
+    // Wait for the server to register that
+    TestHelper.waitUntilTrue(()->room.isPaused(), 2000);
+
+    Assert.assertEquals(true, room.isPaused());
+    PlayerRole pr1 = room.getSlots().get(0).getRole();
+    PlayerRole pr2 = room.getSlots().get(1).getRole();
+    Assert.assertEquals(true, pr1.getPlayer().isShouldBePaused());
+    Assert.assertEquals(true, pr2.getPlayer().isShouldBePaused());
+
+
+    // Wait for it to register
+    // no state will be send if game is paused TestHelper.waitUntilTrue(()->listener.newStateReceived, 2000);
+    listener.newStateReceived = false;
+
+    Assert.assertTrue(TestHelper.waitUntilTrue(()->p1Listener.playerEventReceived, 2000));
+    p1Listener.playerEventReceived = false;
+    Assert.assertEquals(p1Listener.requests.size(), 1);
+    Assert.assertEquals(p1Listener.requests.get(0).getClass(), WelcomeMessage.class);
+
+    player1.sendMessageToRoom(room.getId(), new TestMove(1));
+    TestHelper.waitMills(100);
+    Assert.assertEquals(room.getStatus(), GameRoom.GameStatus.OVER);
+  }
+
+  @Test
   public void stepRequest(){
 
     LobbyClient admin = player1;
@@ -183,23 +240,26 @@ public class RequestTest extends RealServerTest{
 
 
     // Wait for it to register
-    TestHelper.waitUntilTrue(()->listener.newStateReceived, 2000);
+    // no state will be send if game is paused TestHelper.waitUntilTrue(()->listener.newStateReceived, 2000);
     listener.newStateReceived = false;
 
     Assert.assertTrue(TestHelper.waitUntilTrue(()->p1Listener.playerEventReceived, 2000));
     p1Listener.playerEventReceived = false;
+    Assert.assertEquals(p1Listener.requests.size(), 1);
+    Assert.assertEquals(p1Listener.requests.get(0).getClass(), WelcomeMessage.class);
 
-    Assert.assertEquals(p1Listener.requests.get(p1Listener.requests.size()-1).getClass(), TestTurnRequest.class);
-
-    player1.sendMessageToRoom(room.getId(), new TestMove(1));
-    TestHelper.waitMills(100);
+//    enabling this should result in a GameLogicException
+//    player1.sendMessageToRoom(room.getId(), new TestMove(1));
+//    TestHelper.waitMills(100);
 
     // Request a move from the first player
     admin.send(new StepRequest(room.getId()));
     TestHelper.waitUntilTrue(()->listener.newStateReceived, 2000);
+    // send move
+    player1.sendMessageToRoom(room.getId(), new TestMove(1));
     listener.newStateReceived = false;
 
-
+    admin.send(new StepRequest(room.getId()));
     // Wait for second players turn
     TestHelper.waitUntilTrue(()->p2Listener.playerEventReceived, 2000);
     p2Listener.playerEventReceived = false;
@@ -216,7 +276,6 @@ public class RequestTest extends RealServerTest{
     // Should register as a new state
     TestHelper.waitUntilTrue(()->listener.newStateReceived, 2000);
     listener.newStateReceived = false;
-
     // Wait for it to register
     TestHelper.waitUntilTrue(()->p1Listener.playerEventReceived, 2000);
 
@@ -326,25 +385,26 @@ public class RequestTest extends RealServerTest{
     splayer2.addPlayerListener(p2Listener);
     splayer2.setDisplayName("player2...");
 
-
     Assert.assertFalse(room.isPaused());
     TestHelper.waitUntilEqual(2, ()->p1Listener.requests.size(), 2000);
     Assert.assertEquals(p1Listener.requests.get(0).getClass(), WelcomeMessage.class);
     TestHelper.waitMills(500);
     Assert.assertEquals(p1Listener.requests.get(1).getClass(), TestTurnRequest.class);
     listener.newStateReceived = false;
+
     player1.send(new PauseGameRequest(room.getId(), true));
     TestHelper.waitUntilEqual(true,()->room.isPaused(), 2000);
 
     player1.sendMessageToRoom(room.getId(), new TestMove(42));
-    TestHelper.waitMills(500);
+    TestHelper.waitMills(1000);
+    // assert that (if the game is paused) no new gameState is send to the observers after a pending Request was received
     Assert.assertFalse(listener.newStateReceived);
 
 
     p1Listener.playerEventReceived = false;
     p2Listener.playerEventReceived = false;
     player1.send(new PauseGameRequest(room.getId(), false));
-    TestHelper.waitUntilEqual(false,()->room.isPaused(), 2000);
+    TestHelper.waitUntilEqual(false,()->((RoundBasedGameInstance)room.getGame()).isPaused(), 2000);
 
 
 
@@ -352,11 +412,6 @@ public class RequestTest extends RealServerTest{
     Assert.assertTrue(p2Listener.playerEventReceived);
     Assert.assertEquals(p2Listener.requests.get(p2Listener.requests.size()-1).getClass(),
             TestTurnRequest.class);
-
-
-
-
-
   }
 
 }

--- a/game_server/test/sc/server/roles/PlayerTest.java
+++ b/game_server/test/sc/server/roles/PlayerTest.java
@@ -8,6 +8,7 @@ import sc.api.plugins.exceptions.RescuableClientException;
 import sc.protocol.requests.*;
 import sc.protocol.responses.*;
 import sc.protocol.responses.PrepareGameProtocolMessage;
+import sc.server.gaming.GameRoom;
 import sc.server.network.Client;
 import sc.server.network.MockClient;
 import sc.server.network.PacketCallback;

--- a/software_challenge_sdk/src/server_api/sc/framework/plugins/RoundBasedGameInstance.java
+++ b/software_challenge_sdk/src/server_api/sc/framework/plugins/RoundBasedGameInstance.java
@@ -223,8 +223,7 @@ public abstract class RoundBasedGameInstance<P extends SimplePlayer> implements 
   }
 
   public final boolean isPaused() {
-
-    return (this.paused.isPresent() && this.paused.get() <= this.turn);
+    return this.paused.map(inTurn -> this.turn >= inTurn).orElse(false);
   }
 
 

--- a/software_challenge_sdk/src/server_api/sc/framework/plugins/RoundBasedGameInstance.java
+++ b/software_challenge_sdk/src/server_api/sc/framework/plugins/RoundBasedGameInstance.java
@@ -93,7 +93,7 @@ public abstract class RoundBasedGameInstance<P extends SimplePlayer> implements 
    * Checks if goal is reached
    *
    * @return WinCondition with winner and reason or null, if no win condition is
-   *         yet met.
+   * yet met.
    */
   protected abstract WinCondition checkWinCondition();
 
@@ -224,7 +224,7 @@ public abstract class RoundBasedGameInstance<P extends SimplePlayer> implements 
 
   public final boolean isPaused() {
 
-    return (this.paused.isPresent() && this.paused.get() >= this.turn);
+    return (this.paused.isPresent() && this.paused.get() <= this.turn);
   }
 
 
@@ -306,8 +306,10 @@ public abstract class RoundBasedGameInstance<P extends SimplePlayer> implements 
 
   /**
    * Catch block, after an invalid move was performed
-   * @param e catched Exception
+   *
+   * @param e      catched Exception
    * @param author player, that caused the exception
+   *
    * @throws GameLogicException Always thrown
    */
   public void catchInvalidMove(InvalidMoveException e, SimplePlayer author) throws GameLogicException {

--- a/software_challenge_sdk/src/server_api/sc/protocol/requests/PauseGameRequest.java
+++ b/software_challenge_sdk/src/server_api/sc/protocol/requests/PauseGameRequest.java
@@ -6,6 +6,10 @@ import sc.protocol.responses.ProtocolMessage;
 
 /**
  * Request by administrative client to pause or unpause a game specified by given roomId.
+ * A game will only be paused immediately, if there is no pending MoveRequest. If there is a pending
+ * MoveRequest the game will be paused in the next turn.
+ * If the game is paused no GameState or MoveRequest will be send to the players (and all other observers).
+ * These are only send after a an AdminClient sends a StepRequest or resumes the game.
  */
 
 @XStreamAlias("pause")


### PR DESCRIPTION
Die pause funktioniert jetzt folgendermaßen:
Das Spiel wird nur pausiert, wenn kein Zug eines Spielers mehr aussteht. Das heißt sollte eine pause angefordert werden wird diese eventuell erst im nächsten Zug ausgeführt.
Ist das Spiel pausiert, wird kein GameState und kein MoveRequest an die Spieler gesendet. Dies geschieht erst bei einem StepRequest oder sobald das Spiel wieder fortgesetzt wird.