### PR TITLE
fix bugs from merge and fixt <= bug in possibleMoves

### DIFF
--- a/game_players/hase_und_igel_2018/src/sc/player2018/Starter.java
+++ b/game_players/hase_und_igel_2018/src/sc/player2018/Starter.java
@@ -6,6 +6,7 @@ import jargs.gnu.CmdLineParser.UnknownOptionException;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import sc.framework.plugins.SimplePlayer;
+import sc.player2018.logic.Logic;
 import sc.plugin2018.AbstractClient;
 import sc.plugin2018.IGameHandler;
 import sc.shared.SharedConfiguration;

--- a/game_players/hase_und_igel_2018/src/sc/player2018/logic/Logic.java
+++ b/game_players/hase_und_igel_2018/src/sc/player2018/logic/Logic.java
@@ -1,4 +1,4 @@
-package sc.player2018;
+package sc.player2018.logic;
 
 import java.security.SecureRandom;
 import java.util.ArrayList;
@@ -7,6 +7,7 @@ import java.util.Random;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
+import sc.player2018.Starter;
 import sc.plugin2018.*;
 import sc.plugin2018.util.Constants;
 import sc.shared.PlayerColor;
@@ -115,8 +116,10 @@ public class Logic implements IGameHandler {
       log.info("Sende Zug zum Salatessen");
       move = saladMoves.get(rand.nextInt(saladMoves.size()));
     } else if (!selectedMoves.isEmpty()) {
+      log.info("Sende ausgewählten Zug");
       move = selectedMoves.get(rand.nextInt(selectedMoves.size()));
     } else {
+      log.info("Sende irgendeinen Zug");
       move = possibleMove.get(rand.nextInt(possibleMove.size()));
     }
     move.orderActions();

--- a/game_plugins/hase_und_igel_2018/server/sc/plugin2018/Game.java
+++ b/game_plugins/hase_und_igel_2018/server/sc/plugin2018/Game.java
@@ -18,6 +18,7 @@ import sc.framework.plugins.RoundBasedGameInstance;
 import sc.framework.plugins.SimplePlayer;
 import sc.protocol.responses.ProtocolMessage;
 import sc.shared.*;
+import sc.shared.WelcomeMessage;
 import sc.plugin2018.util.Configuration;
 import sc.plugin2018.util.Constants;
 

--- a/game_plugins/hase_und_igel_2018/shared/sc/plugin2018/GameState.java
+++ b/game_plugins/hase_und_igel_2018/shared/sc/plugin2018/GameState.java
@@ -584,7 +584,7 @@ public class GameState implements Cloneable {
       actions.clear();
     }
     // Generiere mögliche Vorwärtszüge
-    for (int i = 1; i < GameRuleLogic.calculateMoveableFields(this.getCurrentPlayer().getCarrots()); i++) {
+    for (int i = 1; i <= GameRuleLogic.calculateMoveableFields(this.getCurrentPlayer().getCarrots()); i++) {
       GameState clone = null;
       try {
         clone = this.clone();


### PR DESCRIPTION
Ein paar der imports and packet-declarationen scheine durch den merge kaputt gegangen zu sein, die wurden hier gefixt. In getPossibleMoves wurde der höchst mögliche Advance-Zug bisher nicht betrachtet, wegen eines <=/< Fehlers.