### PR TITLE
Fix too early timeout

### DIFF
--- a/server/src/sc/server/Lobby.kt
+++ b/server/src/sc/server/Lobby.kt
@@ -56,7 +56,7 @@ class Lobby : IClientListener {
 
     /** handle requests or moves of clients  */
     @Throws(RescuableClientException::class, InvalidGameStateException::class)
-    override fun onRequest(source: Client, callback: PacketCallback) {
+    override fun onRequest(source: Client, callback: PacketCallback, time: Long) {
         val packet = callback.packet
         if (packet is ILobbyRequest) {
             when (packet) {
@@ -82,7 +82,7 @@ class Lobby : IClientListener {
                 is RoomPacket -> {
                     // i.e. new move
                     val room = this.gameManager.findRoom(packet.roomId)
-                    room.onEvent(source, packet.data)
+                    room.onEvent(source, packet.data, time)
                 }
                 is ObservationRequest -> if (source.isAdministrator) {
                     val room = this.gameManager.findRoom(packet.roomId)

--- a/server/src/sc/server/gaming/GameRoom.java
+++ b/server/src/sc/server/gaming/GameRoom.java
@@ -485,12 +485,12 @@ public class GameRoom implements IGameListener {
    *
    * @throws RescuableClientException
    */
-  public synchronized void onEvent(Client source, ProtocolMessage data) throws RescuableClientException, InvalidGameStateException {
+  public synchronized void onEvent(Client source, ProtocolMessage data, long time) throws RescuableClientException, InvalidGameStateException {
     if (isOver())
       throw new RescuableClientException("Game is already over, but got data: " + data.getClass());
 
     try {
-      this.game.onAction(resolvePlayer(source), data);
+      this.game.onAction(resolvePlayer(source), data, time);
     } catch (InvalidMoveException e) {
       this.observerBroadcast(new RoomPacket(this.id, new ProtocolErrorMessage(e.move, e.getMessage())));
       throw new GameLogicException(e.toString());

--- a/server/src/sc/server/network/Client.java
+++ b/server/src/sc/server/network/Client.java
@@ -84,13 +84,15 @@ public class Client extends XStreamClient implements IClient {
      * in the receiver thread.
      */
 
+    long time = System.nanoTime() / 1000000;
+
     Collection<RescuableClientException> errors = new ArrayList<>();
 
     PacketCallback callback = new PacketCallback(packet);
 
     for (IClientListener listener : this.clientListeners) {
       try {
-        listener.onRequest(this, callback);
+        listener.onRequest(this, callback, time);
       } catch (RescuableClientException e) {
         errors.add(e);
       }

--- a/server/src/sc/server/network/ClientManager.java
+++ b/server/src/sc/server/network/ClientManager.java
@@ -151,7 +151,7 @@ public class ClientManager implements Runnable, IClientListener {
    * @throws RescuableClientException never
    */
   @Override
-  public void onRequest(Client source, PacketCallback packet)
+  public void onRequest(Client source, PacketCallback packet, long time)
       throws RescuableClientException {
     // XXX Handle Request?
     

--- a/server/src/sc/server/network/IClientListener.java
+++ b/server/src/sc/server/network/IClientListener.java
@@ -14,7 +14,7 @@ public interface IClientListener {
   void onClientDisconnected(Client source);
 
   /** Invoked when new data is received and ready to be processed. */
-  void onRequest(Client source, PacketCallback packet)
+  void onRequest(Client source, PacketCallback packet, long time)
           throws RescuableClientException, InvalidGameStateException;
 
   /**

--- a/server/test/sc/server/network/ClientXmlReadTest.java
+++ b/server/test/sc/server/network/ClientXmlReadTest.java
@@ -19,7 +19,7 @@ public class ClientXmlReadTest
 		public Object	LastPacket = null;
 
 		@Override
-		public void onRequest(Client source, PacketCallback callback)
+		public void onRequest(Client source, PacketCallback callback, long time)
 		{
 			callback.setProcessed();
 			this.LastPacket = callback.getPacket();

--- a/server/test/sc/server/roles/AdministratorTest.java
+++ b/server/test/sc/server/roles/AdministratorTest.java
@@ -38,7 +38,7 @@ public class AdministratorTest extends AbstractRoleTest
 		try
 		{
 			this.lobby.onRequest(client, new PacketCallback(new AuthenticateRequest(
-					WRONG_PASSWORD)));
+					WRONG_PASSWORD)), System.nanoTime() / 1000000);
 			Assert.fail("No exception was thrown");
 		}
 		catch (RescuableClientException e)
@@ -59,7 +59,7 @@ public class AdministratorTest extends AbstractRoleTest
 		try
 		{
 			this.lobby.onRequest(client, new PacketCallback(new AuthenticateRequest(
-					CORRECT_PASSWORD)));
+					CORRECT_PASSWORD)), System.nanoTime() / 1000000);
 		}
 		catch (RescuableClientException e)
 		{
@@ -74,7 +74,7 @@ public class AdministratorTest extends AbstractRoleTest
 		Client client = connectAsAdmin();
 
 		this.lobby.onRequest(client, new PacketCallback(new PrepareGameRequest(
-				TestPlugin.TEST_PLUGIN_UUID)));
+				TestPlugin.TEST_PLUGIN_UUID)), System.nanoTime() / 1000000);
 
 		Assert.assertEquals(1, this.gameMgr.getGames().size());
 	}

--- a/server/test/sc/server/roles/ContestTest.java
+++ b/server/test/sc/server/roles/ContestTest.java
@@ -25,7 +25,7 @@ public class ContestTest extends AdministratorTest
 		Client player2 = connectClient();
 
 		this.lobby.onRequest(admin, new PacketCallback(new PrepareGameRequest(
-				TestPlugin.TEST_PLUGIN_UUID)));
+				TestPlugin.TEST_PLUGIN_UUID)), System.nanoTime() / 1000000);
 
 		Assert.assertEquals(1, this.gameMgr.getGames().size());
 		GameRoom room = this.gameMgr.getGames().iterator().next();
@@ -36,9 +36,9 @@ public class ContestTest extends AdministratorTest
 		Assert.assertEquals(2, room.getSlots().size());
 
 		this.lobby.onRequest(player1, new PacketCallback(new JoinPreparedRoomRequest(response
-				.getReservations().get(1))));
+				.getReservations().get(1))), System.nanoTime() / 1000000);
 		this.lobby.onRequest(player2, new PacketCallback(new JoinPreparedRoomRequest(response
-				.getReservations().get(0))));
+				.getReservations().get(0))), System.nanoTime() / 1000000);
 
 		Assert.assertEquals(2, room.getSlots().size());
 

--- a/server/test/sc/server/roles/PlayerTest.java
+++ b/server/test/sc/server/roles/PlayerTest.java
@@ -27,7 +27,7 @@ public class PlayerTest extends AbstractRoleTest {
     Client client = connectClient();
 
     this.lobby.onRequest(client, new PacketCallback(new JoinRoomRequest(
-            TestPlugin.TEST_PLUGIN_UUID)));
+            TestPlugin.TEST_PLUGIN_UUID)), System.nanoTime() / 1000000);
 
     Assert.assertEquals(1, this.gameMgr.getGames().size());
     Assert.assertEquals(1, client.getRoles().size());
@@ -39,9 +39,9 @@ public class PlayerTest extends AbstractRoleTest {
     MockClient player2 = connectClient();
 
     this.lobby.onRequest(player1, new PacketCallback(new JoinRoomRequest(
-            TestPlugin.TEST_PLUGIN_UUID)));
+            TestPlugin.TEST_PLUGIN_UUID)), System.nanoTime() / 1000000);
     this.lobby.onRequest(player2, new PacketCallback(new JoinRoomRequest(
-            TestPlugin.TEST_PLUGIN_UUID)));
+            TestPlugin.TEST_PLUGIN_UUID)), System.nanoTime() / 1000000);
 
     Assert.assertEquals(1, this.gameMgr.getGames().size());
 
@@ -69,15 +69,16 @@ public class PlayerTest extends AbstractRoleTest {
     SlotDescriptor slot1 = new SlotDescriptor("player1", true, false);
     SlotDescriptor slot2 = new SlotDescriptor("player2", true, false);
 
-    this.lobby.onRequest(admin, new PacketCallback(new PrepareGameRequest(TestPlugin.TEST_PLUGIN_UUID, slot1, slot2)));
+    this.lobby.onRequest(admin, new PacketCallback(new PrepareGameRequest(TestPlugin.TEST_PLUGIN_UUID, slot1, slot2)),
+            System.nanoTime() / 1000000);
     PrepareGameProtocolMessage prepared = admin.seekMessage(PrepareGameProtocolMessage.class);
 
     this.lobby.onRequest(observer, new PacketCallback(
-            new ObservationRequest(prepared.getRoomId())));
+            new ObservationRequest(prepared.getRoomId())), System.nanoTime() / 1000000);
     this.lobby.onRequest(player1, new PacketCallback(
-            new JoinPreparedRoomRequest(prepared.getReservations().get(0))));
+            new JoinPreparedRoomRequest(prepared.getReservations().get(0))), System.nanoTime() / 1000000);
     this.lobby.onRequest(player2, new PacketCallback(
-            new JoinPreparedRoomRequest(prepared.getReservations().get(1))));
+            new JoinPreparedRoomRequest(prepared.getReservations().get(1))), System.nanoTime() / 1000000);
 
     String roomId = player1.seekMessage(JoinGameProtocolMessage.class).getRoomId();
     String roomId2 = player2.seekMessage(JoinGameProtocolMessage.class)
@@ -112,7 +113,7 @@ public class PlayerTest extends AbstractRoleTest {
     // Do the move
     player1.seekRoomMessage(roomId, TestTurnRequest.class);
     this.lobby.onRequest(player1, new PacketCallback(new RoomPacket(roomId,
-            new TestMove(this.firstState))));
+            new TestMove(this.firstState))), System.nanoTime() / 1000000);
 
     // Check Player 1
     MementoPacket memento1 = player1.seekRoomMessage(roomId,
@@ -134,7 +135,7 @@ public class PlayerTest extends AbstractRoleTest {
           throws RescuableClientException, InvalidGameStateException {
     player.seekRoomMessage(roomId, TestTurnRequest.class);
     this.lobby.onRequest(player, new PacketCallback(new RoomPacket(roomId,
-            new TestMove(123456))));
+            new TestMove(123456))), System.nanoTime() / 1000000);
   }
 
   private void shouldPropagateSecondPlayersMove(String roomId,
@@ -143,7 +144,7 @@ public class PlayerTest extends AbstractRoleTest {
     // Do the move
     player2.seekRoomMessage(roomId, TestTurnRequest.class);
     this.lobby.onRequest(player2, new PacketCallback(new RoomPacket(roomId,
-            new TestMove(this.secondState))));
+            new TestMove(this.secondState))), System.nanoTime() / 1000000);
 
     // Player 1
     MementoPacket memento1 = player1.seekRoomMessage(roomId,

--- a/socha-sdk/src/server-api/sc/api/plugins/IGameInstance.java
+++ b/socha-sdk/src/server-api/sc/api/plugins/IGameInstance.java
@@ -34,7 +34,7 @@ public interface IGameInstance {
    * @throws GameLogicException   if any invalid action is done
    * @throws InvalidMoveException if the received move violates the rules
    */
-  void onAction(Player fromPlayer, ProtocolMessage data)
+  void onAction(Player fromPlayer, ProtocolMessage data, long time)
           throws GameLogicException, InvalidGameStateException, InvalidMoveException;
 
   /**

--- a/socha-sdk/src/server-api/sc/framework/plugins/ActionTimeout.java
+++ b/socha-sdk/src/server-api/sc/framework/plugins/ActionTimeout.java
@@ -74,7 +74,7 @@ public class ActionTimeout {
     return false;
   }
 
-  public synchronized void stop() {
+  public synchronized void stop(long time) {
     if (this.status == Status.NEW) {
       throw new IllegalStateException("Timeout was never started.");
     }
@@ -84,7 +84,7 @@ public class ActionTimeout {
       return;
     }
 
-    this.stopTimestamp = System.nanoTime() / 1000000; // in milliseconds
+    this.stopTimestamp = time; // in milliseconds
     this.status = Status.STOPPED;
 
     if (this.timeoutThread != null) {
@@ -103,7 +103,7 @@ public class ActionTimeout {
         public void run() {
           try {
             Thread.sleep(getHardTimeout());
-            stop();
+            stop(System.nanoTime() / 1000000);
             onTimeout.run();
           } catch (InterruptedException e) {
             logger.info("HardTimout wasn't reached.");

--- a/socha-sdk/src/server-api/sc/framework/plugins/RoundBasedGameInstance.java
+++ b/socha-sdk/src/server-api/sc/framework/plugins/RoundBasedGameInstance.java
@@ -49,12 +49,12 @@ public abstract class RoundBasedGameInstance<P extends Player> implements IGameI
    *
    * @throws GameLogicException if any invalid action is done, i.e. game rule violation
    */
-  public final void onAction(Player fromPlayer, ProtocolMessage data)
+  public final void onAction(Player fromPlayer, ProtocolMessage data, long time)
           throws GameLogicException, InvalidGameStateException, InvalidMoveException {
     Optional<String> errorMsg = Optional.empty();
     if (fromPlayer.equals(this.activePlayer)) {
       if (wasMoveRequested()) {
-        this.requestTimeout.stop();
+        this.requestTimeout.stop(time);
 
         if (this.requestTimeout.didTimeout()) {
           logger.warn("Client hit soft-timeout.");
@@ -101,7 +101,7 @@ public abstract class RoundBasedGameInstance<P extends Player> implements IGameI
     logger.info("Destroying Game");
 
     if (this.requestTimeout != null) {
-      this.requestTimeout.stop();
+      this.requestTimeout.stop(System.nanoTime() / 1000000);
       this.requestTimeout = null;
     }
   }


### PR DESCRIPTION
Diese Verbesserung behebt das Problem, dass der Server den Timer für das Timeout erst einige Millisekunden nach dem Abschicken des Spielzug stoppt.

Sobald das Packet vom Client empfangen wurde wird die aktuelle Zeit gespeichert, diese wird dann als Stopptimestamp für den Timer verwendet.