### PR TITLE
feat(plugin): add `getPossibleMoves` function

### DIFF
--- a/plugin/src/shared/sc/plugin2021/Board.kt
+++ b/plugin/src/shared/sc/plugin2021/Board.kt
@@ -3,7 +3,6 @@ package sc.plugin2021
 import com.thoughtworks.xstream.annotations.XStreamAlias
 import sc.api.plugins.IBoard
 import sc.plugin2021.util.Constants
-import sc.plugin2021.Field
 
 @XStreamAlias(value = "board")
 class Board(
@@ -49,5 +48,29 @@ class Board(
         return gameField.joinToString(separator = "") {
             "${it.joinToString(separator = "  ") { it.letter.toString() }}\n"
         }
+    }
+}
+
+/** The four corners on the Board, used to calculate the position of a piece in a corner. */
+enum class Corner(val position: Coordinates) {
+    UPPER_LEFT(Coordinates(0, 0)) {
+        override fun align(area: Vector): Coordinates = position
+    },
+    UPPER_RIGHT(Coordinates(Constants.BOARD_SIZE - 1, 0)) {
+        override fun align(area: Vector): Coordinates = Coordinates(position.x - area.dx, position.y)
+    },
+    LOWER_RIGHT(Coordinates(Constants.BOARD_SIZE - 1, Constants.BOARD_SIZE - 1)) {
+        override fun align(area: Vector): Coordinates = position - area
+    },
+    LOWER_LEFT(Coordinates(0, Constants.BOARD_SIZE - 1)) {
+        override fun align(area: Vector): Coordinates = Coordinates(position.x, position.y - area.dy)
+    };
+    
+    /** Returns the position a piece of given area has to be placed at to lie in the respective corner. */
+    abstract fun align(area: Vector): Coordinates
+    
+    companion object {
+        /** Returns a set of the positions of all corners. */
+        fun asSet(): Set<Coordinates> = values().map { it.position }.toSet()
     }
 }

--- a/plugin/src/shared/sc/plugin2021/Coordinates.kt
+++ b/plugin/src/shared/sc/plugin2021/Coordinates.kt
@@ -2,6 +2,7 @@ package sc.plugin2021
 
 import com.thoughtworks.xstream.annotations.XStreamAlias
 import com.thoughtworks.xstream.annotations.XStreamAsAttribute
+import kotlin.math.min
 
 @XStreamAlias(value = "coordinates")
 data class Coordinates(
@@ -34,5 +35,9 @@ data class Vector(
     operator fun times(scalar: Int): Vector {
         return Vector(scalar * dx, scalar * dy)
     }
+    
+    operator fun compareTo(other: Vector): Int =
+            min(other.dx - dx, other.dy - dy)
+    
     operator fun unaryPlus(): Coordinates = Coordinates(dx, dy)
 }

--- a/plugin/src/shared/sc/plugin2021/Piece.kt
+++ b/plugin/src/shared/sc/plugin2021/Piece.kt
@@ -2,11 +2,6 @@ package sc.plugin2021
 
 import com.thoughtworks.xstream.annotations.XStreamAlias
 import com.thoughtworks.xstream.annotations.XStreamAsAttribute
-import com.thoughtworks.xstream.annotations.XStreamOmitField
-import sc.plugin2021.util.align
-import sc.plugin2021.util.flip
-import sc.plugin2021.util.print
-import sc.plugin2021.util.rotate
 
 /** A Piece has a color, a position and a normalised shape. */
 @XStreamAlias(value = "piece")
@@ -22,6 +17,15 @@ class Piece(@XStreamAsAttribute val color: Color = Color.BLUE,
                 isFlipped: Boolean = false,
                 position: Coordinates = Coordinates.origin):
             this(color, PieceShape.shapes.getValue(kind), rotation, isFlipped, position)
+    
+    constructor(color: Color = Color.BLUE,
+                kind: PieceShape = PieceShape.MONO,
+                shape: Set<Coordinates>,
+                position: Coordinates = Coordinates.origin):
+            this(color, kind, kind.variants.getValue(shape), position)
+    
+    private constructor(color: Color, kind: PieceShape, transformation: Pair<Rotation, Boolean>, position: Coordinates):
+            this(color, kind, transformation.first, transformation.second, position)
     
     val shape: Set<Coordinates>
         get() = lazyShape()

--- a/plugin/src/shared/sc/plugin2021/PieceShape.kt
+++ b/plugin/src/shared/sc/plugin2021/PieceShape.kt
@@ -3,10 +3,7 @@ package sc.plugin2021
 import com.thoughtworks.xstream.annotations.XStreamAlias
 import com.thoughtworks.xstream.annotations.XStreamAsAttribute
 import com.thoughtworks.xstream.annotations.XStreamOmitField
-import sc.plugin2021.util.Constants
-import sc.plugin2021.util.align
-import sc.plugin2021.util.rotate
-import sc.plugin2021.util.flip
+import sc.plugin2021.util.*
 import kotlin.math.max
 
 @XStreamAlias(value = "shape")
@@ -43,6 +40,9 @@ enum class PieceShape(coordinates: Set<Coordinates>) {
     @XStreamOmitField
     val size: Int = coordinates.size
     
+    /** All different variants. Boiler plate for faster calculation of possible moves. */
+    val variants: Map<Set<Coordinates>, Pair<Rotation, Boolean>>
+    
     init {
         var dx = 0
         var dy = 0
@@ -51,8 +51,18 @@ enum class PieceShape(coordinates: Set<Coordinates>) {
             dy = max(it.y, dy)
         }
         dimension = Vector(dx, dy)
-    }
     
+    
+        val mapVariants = mutableMapOf<Set<Coordinates>, Pair<Rotation, Boolean>>()
+        for (rotation in Rotation.values()) {
+            for (flip in listOf(false, true)) {
+                val shape = coordinates.rotate(rotation).flip(flip)
+                if (mapVariants[shape] == null) mapVariants += shape to Pair(rotation, flip)
+            }
+        }
+        variants = mapVariants
+    }
+
     /** Applies all the given transformations. */
     fun transform(rotation: Rotation, shouldFlip: Boolean): Set<Coordinates> =
             coordinates.rotate(rotation).flip(shouldFlip)

--- a/plugin/src/shared/sc/plugin2021/PieceShape.kt
+++ b/plugin/src/shared/sc/plugin2021/PieceShape.kt
@@ -33,10 +33,12 @@ enum class PieceShape(coordinates: Set<Coordinates>) {
     
     @XStreamAsAttribute
     val coordinates: Set<Coordinates> = coordinates.align()
+    
     @XStreamAsAttribute
-    val dimension: Vector
+    val dimension: Vector = coordinates.area()
     
     val asVectors: Set<Vector> by lazy {coordinates.map {it - Coordinates.origin}.toSet()}
+    
     @XStreamOmitField
     val size: Int = coordinates.size
     
@@ -46,15 +48,6 @@ enum class PieceShape(coordinates: Set<Coordinates>) {
     val transformations: Map<Pair<Rotation, Boolean>, Set<Coordinates>>
     
     init {
-        var dx = 0
-        var dy = 0
-        coordinates.forEach {
-            dx = max(it.x, dx)
-            dy = max(it.y, dy)
-        }
-        dimension = Vector(dx, dy)
-    
-    
         val mapVariants = mutableMapOf<Set<Coordinates>, Pair<Rotation, Boolean>>()
         val mapTransformations = mutableMapOf<Pair<Rotation, Boolean>, Set<Coordinates>>()
         for (rotation in Rotation.values()) {

--- a/plugin/src/shared/sc/plugin2021/PieceShape.kt
+++ b/plugin/src/shared/sc/plugin2021/PieceShape.kt
@@ -43,6 +43,8 @@ enum class PieceShape(coordinates: Set<Coordinates>) {
     /** All different variants. Boiler plate for faster calculation of possible moves. */
     val variants: Map<Set<Coordinates>, Pair<Rotation, Boolean>>
     
+    val transformations: Map<Pair<Rotation, Boolean>, Set<Coordinates>>
+    
     init {
         var dx = 0
         var dy = 0
@@ -54,14 +56,22 @@ enum class PieceShape(coordinates: Set<Coordinates>) {
     
     
         val mapVariants = mutableMapOf<Set<Coordinates>, Pair<Rotation, Boolean>>()
+        val mapTransformations = mutableMapOf<Pair<Rotation, Boolean>, Set<Coordinates>>()
         for (rotation in Rotation.values()) {
             for (flip in listOf(false, true)) {
                 val shape = coordinates.rotate(rotation).flip(flip)
                 if (mapVariants[shape] == null) mapVariants += shape to Pair(rotation, flip)
+                mapTransformations += Pair(rotation, flip) to shape
             }
         }
         variants = mapVariants
+        transformations = mapTransformations
     }
+    
+    /** Does the same thing as transform, using the variants list. */
+    operator fun get(rotation: Rotation, shouldFlip: Boolean): Set<Coordinates> =
+            transformations[rotation to shouldFlip] ?: emptySet()
+            
 
     /** Applies all the given transformations. */
     fun transform(rotation: Rotation, shouldFlip: Boolean): Set<Coordinates> =

--- a/plugin/src/shared/sc/plugin2021/PieceShape.kt
+++ b/plugin/src/shared/sc/plugin2021/PieceShape.kt
@@ -68,13 +68,16 @@ enum class PieceShape(coordinates: Set<Coordinates>) {
         transformations = mapTransformations
     }
     
-    /** Does the same thing as transform, using the variants list. */
+    /** Does the same thing as transform, providing the index operator. */
     operator fun get(rotation: Rotation, shouldFlip: Boolean): Set<Coordinates> =
-            transformations[rotation to shouldFlip] ?: emptySet()
-            
-
-    /** Applies all the given transformations. */
+            transform(rotation, shouldFlip)
+    
+    /** Returns a shape with all transformations applied. */
     fun transform(rotation: Rotation, shouldFlip: Boolean): Set<Coordinates> =
+            transformations[rotation to shouldFlip] ?: emptySet()
+    
+    /** Applies all the given transformations manually instead of looking them up. */
+    fun legacyTransform(rotation: Rotation, shouldFlip: Boolean): Set<Coordinates> =
             coordinates.rotate(rotation).flip(shouldFlip)
     
     companion object {

--- a/plugin/src/shared/sc/plugin2021/util/GameRuleLogic.kt
+++ b/plugin/src/shared/sc/plugin2021/util/GameRuleLogic.kt
@@ -3,6 +3,7 @@ package sc.plugin2021.util
 import org.slf4j.LoggerFactory
 import sc.plugin2021.*
 import sc.shared.InvalidMoveException
+import kotlin.contracts.contract
 import kotlin.properties.Delegates
 
 object GameRuleLogic {
@@ -142,17 +143,52 @@ object GameRuleLogic {
     /** Returns a list of all possible SetMoves. */
     @JvmStatic
     fun getPossibleMoves(gameState: GameState): Set<SetMove> {
-        if (gameState.round == 1) return getPossibleStartMoves(gameState)
-        val color = gameState.currentColor
+//        if (gameState.round == 1) return getPossibleStartMoves(gameState)
+//        val color = gameState.currentColor
+//
+//        return emptySet()
         
-        return emptySet()
+        return getAllMoves(gameState).filter {
+            try {
+                validateMoveColor(gameState, it)
+                validateSetMove(gameState, it)
+                true
+            } catch (e: InvalidMoveException) {
+                false
+            }
+        }.toSet()
     }
     
-    /** Returns a list of possible SetMoves if it's the first round. */
+//    /** Returns a list of possible SetMoves if it's the first round. */
+//    @JvmStatic
+//    fun getPossibleStartMoves(gameState: GameState): Set<SetMove> {
+//        val color = gameState.currentColor
+//
+//        return emptySet()
+//    }
+    
+    /**
+     * Returns a list of all moves, impossible or not.
+     *  There's no real usage, except maybe for cases where no Move validation happens
+     *  if `Constants.VALIDATE_MOVE` is false, then this function should return the same
+     *  Set as `::getPossibleMoves`
+     */
     @JvmStatic
-    fun getPossibleStartMoves(gameState: GameState): Set<SetMove> {
-        val color = gameState.currentColor
-        
-        return emptySet()
+    fun getAllMoves(gameState: GameState): Set<SetMove> {
+        val moves = mutableSetOf<SetMove>()
+        for (color in Color.values()) {
+            for (shape in PieceShape.values()) {
+                for (rotation in Rotation.values()) {
+                    for (flip in listOf(false, true)) {
+                        for (y in 0 until Constants.BOARD_SIZE) {
+                            for (x in 0 until Constants.BOARD_SIZE) {
+                                moves.add(SetMove(Piece(color, shape, rotation, flip, Coordinates(x, y))))
+                            }
+                        }
+                    }
+                }
+            }
+        }
+        return moves
     }
 }

--- a/plugin/src/shared/sc/plugin2021/util/GameRuleLogic.kt
+++ b/plugin/src/shared/sc/plugin2021/util/GameRuleLogic.kt
@@ -139,13 +139,18 @@ object GameRuleLogic {
     @JvmStatic
     fun getPossibleMoves(gameState: GameState): Set<SetMove> {
         // TODO: Use appropriate move calculation here
-        // TODO: assert no move throws
-//        if (gameState.round == 1) return getPossibleStartMoves(gameState)
-//        val color = gameState.currentColor
-//
-//        return emptySet()
-    
-        return getAllMoves(gameState).filterValidMoves(gameState)
+        if (gameState.deployedPieces.getValue(gameState.currentColor).isEmpty()) return getPossibleStartMoves(gameState)
+        val color = gameState.currentColor
+
+        val moves = mutableSetOf<SetMove>()
+        gameState.undeployedPieceShapes.getValue(color).map {
+            val area = it.coordinates.area()
+            for (y in 0 until Constants.BOARD_SIZE - area.dy)
+                for (x in 0 until Constants.BOARD_SIZE - area.dx)
+                    for (variant in it.variants)
+                        moves += SetMove(Piece(color, it, variant.key, Coordinates(x, y)))
+        }
+        return moves
     }
     
     /** Returns a list of possible SetMoves if it's the first round. */

--- a/plugin/src/shared/sc/plugin2021/util/GameRuleLogic.kt
+++ b/plugin/src/shared/sc/plugin2021/util/GameRuleLogic.kt
@@ -3,8 +3,6 @@ package sc.plugin2021.util
 import org.slf4j.LoggerFactory
 import sc.plugin2021.*
 import sc.shared.InvalidMoveException
-import kotlin.contracts.contract
-import kotlin.properties.Delegates
 
 object GameRuleLogic {
     val logger = LoggerFactory.getLogger(GameRuleLogic::class.java)
@@ -143,6 +141,8 @@ object GameRuleLogic {
     /** Returns a list of all possible SetMoves. */
     @JvmStatic
     fun getPossibleMoves(gameState: GameState): Set<SetMove> {
+        // TODO: Use appropriate move calculation here
+        // TODO: assert no move throws
 //        if (gameState.round == 1) return getPossibleStartMoves(gameState)
 //        val color = gameState.currentColor
 //
@@ -159,13 +159,13 @@ object GameRuleLogic {
         }.toSet()
     }
     
-//    /** Returns a list of possible SetMoves if it's the first round. */
-//    @JvmStatic
-//    fun getPossibleStartMoves(gameState: GameState): Set<SetMove> {
-//        val color = gameState.currentColor
-//
-//        return emptySet()
-//    }
+    /** Returns a list of possible SetMoves if it's the first round. */
+    @JvmStatic
+    fun getPossibleStartMoves(gameState: GameState): Set<SetMove> {
+        val color = gameState.currentColor
+        // TODO: calculate possible moves given it's the first turn
+        return emptySet()
+    }
     
     /**
      * Returns a list of all moves, impossible or not.

--- a/plugin/src/shared/sc/plugin2021/util/GameRuleLogic.kt
+++ b/plugin/src/shared/sc/plugin2021/util/GameRuleLogic.kt
@@ -125,11 +125,8 @@ object GameRuleLogic {
     }
     
     @JvmStatic
-    fun isOnCorner(position: Coordinates): Boolean = listOf(
-            Coordinates(0, 0),
-            Coordinates(Constants.BOARD_SIZE - 1, 0),
-            Coordinates(Constants.BOARD_SIZE - 1, Constants.BOARD_SIZE - 1),
-            Coordinates(0, Constants.BOARD_SIZE - 1)).contains(position)
+    fun isOnCorner(position: Coordinates): Boolean =
+            Corner.asSet().contains(position)
     
     /** Returns a random pentomino which is not the `x` one (Used to get a valid starting piece). */
     @JvmStatic
@@ -147,24 +144,22 @@ object GameRuleLogic {
 //        val color = gameState.currentColor
 //
 //        return emptySet()
-        
-        return getAllMoves(gameState).filter {
-            try {
-                validateMoveColor(gameState, it)
-                validateSetMove(gameState, it)
-                true
-            } catch (e: InvalidMoveException) {
-                false
-            }
-        }.toSet()
+    
+        return getAllMoves(gameState).filterValidMoves(gameState)
     }
     
     /** Returns a list of possible SetMoves if it's the first round. */
     @JvmStatic
     fun getPossibleStartMoves(gameState: GameState): Set<SetMove> {
         val color = gameState.currentColor
-        // TODO: calculate possible moves given it's the first turn
-        return emptySet()
+        val kind = gameState.startPiece
+        val moves  = mutableSetOf<SetMove>()
+        for (variant in kind.variants) {
+            for (corner in Corner.values()) {
+                moves.add(SetMove(Piece(color, kind, variant.key, corner.align(variant.key.area()))))
+            }
+        }
+        return moves.filterValidMoves(gameState)
     }
     
     /**

--- a/plugin/src/shared/sc/plugin2021/util/SetHelpers.kt
+++ b/plugin/src/shared/sc/plugin2021/util/SetHelpers.kt
@@ -1,6 +1,8 @@
 package sc.plugin2021.util
 
 import sc.plugin2021.*
+import sc.shared.InvalidMoveException
+import java.lang.IndexOutOfBoundsException
 
 /**
  * A Collection of methods callable on specific Sets or functions that take Sets as input.
@@ -54,13 +56,27 @@ fun Set<Coordinates>.align(): Set<Coordinates> {
     }.toSet()
 }
 
+/** Returns the rectangular area the Set of Coordinates lies in. */
+fun Set<Coordinates>.area(): Vector {
+    var dx = 0
+    var dy = 0
+    forEach {
+        dx = kotlin.math.max(it.x, dx)
+        dy = kotlin.math.max(it.y, dy)
+    }
+    return Vector(dx, dy)
+}
+
 /** Prints an ascii art of the piece. */
-fun Set<Coordinates>.print(dimension: Vector = Vector(4, 5)) {
+fun Set<Coordinates>.print(dimension: Vector = area()) {
     printShapes(this, dimension = dimension)
 }
 
 /** Prints all given shapes next to each other. */
 fun printShapes(vararg shapes: Set<Coordinates>, dimension: Vector = Vector(4, 5)) {
+    if (shapes.any{it.area() < dimension})
+        throw IndexOutOfBoundsException("The largest shape has to fit in the given dimension")
+        
     val width = shapes.size * (dimension.dx + 1)
     val array = Array(dimension.dy * width) {FieldContent.EMPTY.letter}
     for (n in array.indices) {
@@ -77,3 +93,15 @@ fun printShapes(vararg shapes: Set<Coordinates>, dimension: Vector = Vector(4, 5
     }
     println()
 }
+
+/** Filters all moves, returning only those who pass the validation functions. */
+fun Set<SetMove>.filterValidMoves(gameState: GameState): Set<SetMove> =
+        filter {
+            try {
+                GameRuleLogic.validateMoveColor(gameState, it)
+                GameRuleLogic.validateSetMove(gameState, it)
+                true
+            } catch(e: InvalidMoveException) {
+                false
+            }
+        }.toSet()

--- a/plugin/src/test/sc/plugin2021/GameRuleLogicTest.kt
+++ b/plugin/src/test/sc/plugin2021/GameRuleLogicTest.kt
@@ -1,5 +1,6 @@
 package sc.plugin2021
 
+import io.kotlintest.matchers.collections.shouldContainExactlyInAnyOrder
 import io.kotlintest.shouldBe
 import io.kotlintest.shouldNotBe
 import io.kotlintest.specs.StringSpec
@@ -7,13 +8,12 @@ import org.junit.jupiter.api.assertDoesNotThrow
 import org.junit.jupiter.api.assertThrows
 import sc.plugin2021.util.Constants
 import sc.plugin2021.util.GameRuleLogic
-import sc.plugin2021.util.print
 import sc.shared.InvalidMoveException
 
 class GameRuleLogicTest: StringSpec({
     "Color validation works correctly" {
         val gameState = GameState(startPiece = PieceShape.PENTO_U)
-        
+
         assertThrows<InvalidMoveException> {
             val invalidMove = SetMove(Piece(Color.RED))
             GameRuleLogic.performMove(gameState, invalidMove)
@@ -27,7 +27,7 @@ class GameRuleLogicTest: StringSpec({
     "Position validation works" {
         val gameState: GameState = GameState()
         gameState.board[Coordinates(1, 1)] = FieldContent.BLUE
-        
+
         assertThrows<InvalidMoveException> {
             val invalidMove = SetMove(
                     Piece(Color.BLUE, PieceShape.MONO, Rotation.NONE, false, Coordinates(-1, 2)))
@@ -35,10 +35,10 @@ class GameRuleLogicTest: StringSpec({
         }
         GameRuleLogic.isObstructed(gameState.board, Coordinates(1, 1)) shouldBe true
         GameRuleLogic.isObstructed(gameState.board, Coordinates(0, 0)) shouldNotBe true
-        
+
         GameRuleLogic.bordersOnColor(gameState.board, Coordinates(1, 0), Color.BLUE) shouldBe true
         GameRuleLogic.bordersOnColor(gameState.board, Coordinates(0, 0), Color.BLUE) shouldNotBe true
-        
+
         GameRuleLogic.cornersOnColor(gameState.board, Coordinates(0, 0), Color.BLUE) shouldBe true
         GameRuleLogic.cornersOnColor(gameState.board, Coordinates(0, 0), Color.GREEN) shouldNotBe true
         GameRuleLogic.cornersOnColor(gameState.board, Coordinates(1, 0), Color.BLUE) shouldNotBe true
@@ -60,7 +60,7 @@ class GameRuleLogicTest: StringSpec({
                 Piece(Color.RED,    PieceShape.PENTO_S, position = Coordinates(0, Constants.BOARD_SIZE - 2)),
                 Piece(Color.GREEN,  PieceShape.PENTO_S, isFlipped = true)
         )
-        
+
         assertDoesNotThrow {
             val gameState = GameState(startPiece = PieceShape.PENTO_S)
             GameRuleLogic.performMove(gameState, SetMove(validPieces.first()))
@@ -79,7 +79,7 @@ class GameRuleLogicTest: StringSpec({
     }
     "Point score calculation works" {
         GameRuleLogic.getPointsFromDeployedPieces(emptyList()) shouldBe GameRuleLogic.SMALLEST_SCORE_POSSIBLE
-        
+
         val fewPieces = listOf(
                 Piece(Color.BLUE, PieceShape.TRIO_I,  Rotation.NONE, true),
                 Piece(Color.BLUE, PieceShape.TETRO_O, Rotation.NONE, true),
@@ -87,12 +87,12 @@ class GameRuleLogicTest: StringSpec({
                 Piece(Color.BLUE, PieceShape.MONO,    Rotation.NONE, true)
         )
         GameRuleLogic.getPointsFromDeployedPieces(fewPieces) shouldBe -76
-        
+
         val allPieces = PieceShape.shapes.map{
             Piece(Color.BLUE, it.key, Rotation.NONE, false)
         }.toList()
         GameRuleLogic.getPointsFromDeployedPieces(allPieces) shouldBe 15
-        
+
         val perfectPieces = allPieces.reversed()
         GameRuleLogic.getPointsFromDeployedPieces(perfectPieces) shouldBe 20
     }
@@ -105,5 +105,46 @@ class GameRuleLogicTest: StringSpec({
             GameRuleLogic.performMove(gameState, PassMove(Color.BLUE))
         }
         gameState.orderedColors.size shouldBe 3
+    }
+    "All possible moves get calculated" {
+        val state = GameState(startPiece = PieceShape.PENTO_W)
+        var SHOULD = setOf(
+                Piece(Color.BLUE, PieceShape.PENTO_W, Rotation.NONE, false, Coordinates(0, 0)),
+                Piece(Color.BLUE, PieceShape.PENTO_W, Rotation.MIRROR, false, Coordinates(0, 0)),
+                Piece(Color.BLUE, PieceShape.PENTO_W, Rotation.RIGHT, false, Coordinates(17, 0)),
+                Piece(Color.BLUE, PieceShape.PENTO_W, Rotation.LEFT, false, Coordinates(17, 0)),
+                Piece(Color.BLUE, PieceShape.PENTO_W, Rotation.NONE, false, Coordinates(17, 17)),
+                Piece(Color.BLUE, PieceShape.PENTO_W, Rotation.MIRROR, false, Coordinates(17, 17)),
+                Piece(Color.BLUE, PieceShape.PENTO_W, Rotation.RIGHT, false, Coordinates(0, 17)),
+                Piece(Color.BLUE, PieceShape.PENTO_W, Rotation.LEFT, false, Coordinates(0, 17))
+        ).map { SetMove(it) }.toSet()
+        var IS = GameRuleLogic.getPossibleMoves(state)
+        
+        IS shouldContainExactlyInAnyOrder SHOULD
+        GameRuleLogic.performMove(state, SHOULD.first())
+    
+        SHOULD = setOf(
+                Piece(Color.YELLOW, PieceShape.PENTO_W, Rotation.RIGHT, false, Coordinates(17, 0)),
+                Piece(Color.YELLOW, PieceShape.PENTO_W, Rotation.LEFT, false, Coordinates(17, 0)),
+                Piece(Color.YELLOW, PieceShape.PENTO_W, Rotation.NONE, false, Coordinates(17, 17)),
+                Piece(Color.YELLOW, PieceShape.PENTO_W, Rotation.MIRROR, false, Coordinates(17, 17)),
+                Piece(Color.YELLOW, PieceShape.PENTO_W, Rotation.RIGHT, false, Coordinates(0, 17)),
+                Piece(Color.YELLOW, PieceShape.PENTO_W, Rotation.LEFT, false, Coordinates(0, 17))
+        ).map { SetMove(it) }.toSet()
+        IS = GameRuleLogic.getPossibleMoves(state)
+    
+        IS shouldContainExactlyInAnyOrder SHOULD
+        GameRuleLogic.performMove(state, SHOULD.first())
+        
+        SHOULD = setOf(
+                Piece(Color.RED, PieceShape.PENTO_W, Rotation.NONE, false, Coordinates(17, 17)),
+                Piece(Color.RED, PieceShape.PENTO_W, Rotation.MIRROR, false, Coordinates(17, 17)),
+                Piece(Color.RED, PieceShape.PENTO_W, Rotation.RIGHT, false, Coordinates(0, 17)),
+                Piece(Color.RED, PieceShape.PENTO_W, Rotation.LEFT, false, Coordinates(0, 17))
+        ).map { SetMove(it) }.toSet()
+        IS = GameRuleLogic.getPossibleMoves(state)
+        
+        IS shouldContainExactlyInAnyOrder SHOULD
+        GameRuleLogic.performMove(state, SHOULD.first())
     }
 })

--- a/plugin/src/test/sc/plugin2021/GameRuleLogicTest.kt
+++ b/plugin/src/test/sc/plugin2021/GameRuleLogicTest.kt
@@ -146,5 +146,13 @@ class GameRuleLogicTest: StringSpec({
         
         IS shouldContainExactlyInAnyOrder SHOULD
         GameRuleLogic.performMove(state, SHOULD.first())
+        
+        SHOULD = setOf(
+                Piece(Color.GREEN, PieceShape.PENTO_W, Rotation.RIGHT, false, Coordinates(0, 17)),
+                Piece(Color.GREEN, PieceShape.PENTO_W, Rotation.LEFT, false, Coordinates(0, 17))
+        ).map { SetMove(it) }.toSet()
+        IS = GameRuleLogic.getPossibleMoves(state)
+        
+        IS shouldContainExactlyInAnyOrder SHOULD
     }
 })

--- a/plugin/src/test/sc/plugin2021/GameRuleLogicTest.kt
+++ b/plugin/src/test/sc/plugin2021/GameRuleLogicTest.kt
@@ -107,16 +107,17 @@ class GameRuleLogicTest: StringSpec({
         gameState.orderedColors.size shouldBe 3
     }
     "All possible moves get calculated" {
-        val state = GameState(startPiece = PieceShape.PENTO_W)
+        val piece = PieceShape.PENTO_W
+        val state = GameState(startPiece = piece)
         var SHOULD = setOf(
-                Piece(Color.BLUE, PieceShape.PENTO_W, Rotation.NONE, false, Coordinates(0, 0)),
-                Piece(Color.BLUE, PieceShape.PENTO_W, Rotation.MIRROR, false, Coordinates(0, 0)),
-                Piece(Color.BLUE, PieceShape.PENTO_W, Rotation.RIGHT, false, Coordinates(17, 0)),
-                Piece(Color.BLUE, PieceShape.PENTO_W, Rotation.LEFT, false, Coordinates(17, 0)),
-                Piece(Color.BLUE, PieceShape.PENTO_W, Rotation.NONE, false, Coordinates(17, 17)),
-                Piece(Color.BLUE, PieceShape.PENTO_W, Rotation.MIRROR, false, Coordinates(17, 17)),
-                Piece(Color.BLUE, PieceShape.PENTO_W, Rotation.RIGHT, false, Coordinates(0, 17)),
-                Piece(Color.BLUE, PieceShape.PENTO_W, Rotation.LEFT, false, Coordinates(0, 17))
+                Piece(Color.BLUE, piece, Rotation.NONE, false, Coordinates(0, 0)),
+                Piece(Color.BLUE, piece, Rotation.MIRROR, false, Coordinates(0, 0)),
+                Piece(Color.BLUE, piece, Rotation.RIGHT, false, Coordinates(17, 0)),
+                Piece(Color.BLUE, piece, Rotation.LEFT, false, Coordinates(17, 0)),
+                Piece(Color.BLUE, piece, Rotation.NONE, false, Coordinates(17, 17)),
+                Piece(Color.BLUE, piece, Rotation.MIRROR, false, Coordinates(17, 17)),
+                Piece(Color.BLUE, piece, Rotation.RIGHT, false, Coordinates(0, 17)),
+                Piece(Color.BLUE, piece, Rotation.LEFT, false, Coordinates(0, 17))
         ).map { SetMove(it) }.toSet()
         var IS = GameRuleLogic.getPossibleMoves(state)
         
@@ -124,12 +125,12 @@ class GameRuleLogicTest: StringSpec({
         GameRuleLogic.performMove(state, SHOULD.first())
     
         SHOULD = setOf(
-                Piece(Color.YELLOW, PieceShape.PENTO_W, Rotation.RIGHT, false, Coordinates(17, 0)),
-                Piece(Color.YELLOW, PieceShape.PENTO_W, Rotation.LEFT, false, Coordinates(17, 0)),
-                Piece(Color.YELLOW, PieceShape.PENTO_W, Rotation.NONE, false, Coordinates(17, 17)),
-                Piece(Color.YELLOW, PieceShape.PENTO_W, Rotation.MIRROR, false, Coordinates(17, 17)),
-                Piece(Color.YELLOW, PieceShape.PENTO_W, Rotation.RIGHT, false, Coordinates(0, 17)),
-                Piece(Color.YELLOW, PieceShape.PENTO_W, Rotation.LEFT, false, Coordinates(0, 17))
+                Piece(Color.YELLOW, piece, Rotation.RIGHT, false, Coordinates(17, 0)),
+                Piece(Color.YELLOW, piece, Rotation.LEFT, false, Coordinates(17, 0)),
+                Piece(Color.YELLOW, piece, Rotation.NONE, false, Coordinates(17, 17)),
+                Piece(Color.YELLOW, piece, Rotation.MIRROR, false, Coordinates(17, 17)),
+                Piece(Color.YELLOW, piece, Rotation.RIGHT, false, Coordinates(0, 17)),
+                Piece(Color.YELLOW, piece, Rotation.LEFT, false, Coordinates(0, 17))
         ).map { SetMove(it) }.toSet()
         IS = GameRuleLogic.getPossibleMoves(state)
     
@@ -137,10 +138,10 @@ class GameRuleLogicTest: StringSpec({
         GameRuleLogic.performMove(state, SHOULD.first())
         
         SHOULD = setOf(
-                Piece(Color.RED, PieceShape.PENTO_W, Rotation.NONE, false, Coordinates(17, 17)),
-                Piece(Color.RED, PieceShape.PENTO_W, Rotation.MIRROR, false, Coordinates(17, 17)),
-                Piece(Color.RED, PieceShape.PENTO_W, Rotation.RIGHT, false, Coordinates(0, 17)),
-                Piece(Color.RED, PieceShape.PENTO_W, Rotation.LEFT, false, Coordinates(0, 17))
+                Piece(Color.RED, piece, Rotation.NONE, false, Coordinates(17, 17)),
+                Piece(Color.RED, piece, Rotation.MIRROR, false, Coordinates(17, 17)),
+                Piece(Color.RED, piece, Rotation.RIGHT, false, Coordinates(0, 17)),
+                Piece(Color.RED, piece, Rotation.LEFT, false, Coordinates(0, 17))
         ).map { SetMove(it) }.toSet()
         IS = GameRuleLogic.getPossibleMoves(state)
         
@@ -148,8 +149,8 @@ class GameRuleLogicTest: StringSpec({
         GameRuleLogic.performMove(state, SHOULD.first())
         
         SHOULD = setOf(
-                Piece(Color.GREEN, PieceShape.PENTO_W, Rotation.RIGHT, false, Coordinates(0, 17)),
-                Piece(Color.GREEN, PieceShape.PENTO_W, Rotation.LEFT, false, Coordinates(0, 17))
+                Piece(Color.GREEN, piece, Rotation.RIGHT, false, Coordinates(0, 17)),
+                Piece(Color.GREEN, piece, Rotation.LEFT, false, Coordinates(0, 17))
         ).map { SetMove(it) }.toSet()
         IS = GameRuleLogic.getPossibleMoves(state)
         

--- a/plugin/src/test/sc/plugin2021/GameRuleLogicTest.kt
+++ b/plugin/src/test/sc/plugin2021/GameRuleLogicTest.kt
@@ -8,6 +8,7 @@ import org.junit.jupiter.api.assertDoesNotThrow
 import org.junit.jupiter.api.assertThrows
 import sc.plugin2021.util.Constants
 import sc.plugin2021.util.GameRuleLogic
+import sc.plugin2021.util.filterValidMoves
 import sc.shared.InvalidMoveException
 
 class GameRuleLogicTest: StringSpec({
@@ -106,9 +107,9 @@ class GameRuleLogicTest: StringSpec({
         }
         gameState.orderedColors.size shouldBe 3
     }
-    "All possible moves get calculated" {
+    "All possible start moves get calculated" {
         val piece = PieceShape.PENTO_W
-        val state = GameState(startPiece = piece)
+        var state = GameState(startPiece = piece)
         var SHOULD = setOf(
                 Piece(Color.BLUE, piece, Rotation.NONE, false, Coordinates(0, 0)),
                 Piece(Color.BLUE, piece, Rotation.MIRROR, false, Coordinates(0, 0)),
@@ -155,5 +156,15 @@ class GameRuleLogicTest: StringSpec({
         IS = GameRuleLogic.getPossibleMoves(state)
         
         IS shouldContainExactlyInAnyOrder SHOULD
+    
+        state = GameState()
+        GameRuleLogic.getPossibleMoves(state) shouldContainExactlyInAnyOrder
+                GameRuleLogic.getAllMoves(state).filterValidMoves(state)
+    
+        GameRuleLogic.getPossibleMoves(state) shouldContainExactlyInAnyOrder
+                GameRuleLogic.getPossibleMoves(state).filterValidMoves(state)
+    }
+    "All possible moves get calculated" {
+        // TODO: set up a mid-game state so that the list of possible moves is non-trivial
     }
 })

--- a/plugin/src/test/sc/plugin2021/PieceTest.kt
+++ b/plugin/src/test/sc/plugin2021/PieceTest.kt
@@ -227,7 +227,7 @@ class PieceTest: StringSpec({
         PieceShape.values().forEach {
             for (rotation in Rotation.values())
                 for (flip in listOf(false, true))
-                    it[rotation, flip] shouldBe it.transform(rotation, flip)
+                    it[rotation, flip] shouldBe it.legacyTransform(rotation, flip)
         }
     }
 })

--- a/plugin/src/test/sc/plugin2021/PieceTest.kt
+++ b/plugin/src/test/sc/plugin2021/PieceTest.kt
@@ -223,4 +223,11 @@ class PieceTest: StringSpec({
                 PieceShape.TETRO_O.coordinates to Pair(Rotation.NONE, false)
         )
     }
+    "Shape retrieval" {
+        PieceShape.values().forEach {
+            for (rotation in Rotation.values())
+                for (flip in listOf(false, true))
+                    it[rotation, flip] shouldBe it.transform(rotation, flip)
+        }
+    }
 })

--- a/plugin/src/test/sc/plugin2021/PieceTest.kt
+++ b/plugin/src/test/sc/plugin2021/PieceTest.kt
@@ -230,4 +230,12 @@ class PieceTest: StringSpec({
                     it[rotation, flip] shouldBe it.legacyTransform(rotation, flip)
         }
     }
+    "Piece Constructor from Shape" {
+        PieceShape.values().forEach {
+            for (trafo in it.variants) {
+                Piece(kind = it, rotation = trafo.value.first, isFlipped = trafo.value.second) shouldBe
+                        Piece(kind = it, shape = trafo.key)
+            }
+        }
+    }
 })

--- a/plugin/src/test/sc/plugin2021/PieceTest.kt
+++ b/plugin/src/test/sc/plugin2021/PieceTest.kt
@@ -209,10 +209,6 @@ class PieceTest: StringSpec({
                 PieceShape.DOMINO.coordinates to Pair(Rotation.NONE, false),
                 PieceShape.DOMINO.transform(Rotation.RIGHT, false) to Pair(Rotation.RIGHT, false)
         )
-        PieceShape.TRIO_L.variants.forEach {
-            println(it)
-            it.key.print()
-        }
         PieceShape.TRIO_L.variants shouldContainExactly mapOf(
                 PieceShape.TRIO_L.coordinates to Pair(Rotation.NONE, false),
                 PieceShape.TRIO_L.transform(Rotation.NONE, true) to Pair(Rotation.NONE, true),

--- a/plugin/src/test/sc/plugin2021/PieceTest.kt
+++ b/plugin/src/test/sc/plugin2021/PieceTest.kt
@@ -1,7 +1,7 @@
 package sc.plugin2021
 
-import com.thoughtworks.xstream.XStream
-import io.kotlintest.inspectors.forAll
+import io.kotlintest.matchers.maps.shouldContain
+import io.kotlintest.matchers.maps.shouldContainExactly
 import io.kotlintest.shouldBe
 import io.kotlintest.specs.StringSpec
 import org.opentest4j.AssertionFailedError
@@ -122,6 +122,37 @@ class PieceTest: StringSpec({
             }
         }
     }
+    "Test Set transformation arithmetic (TRIO_L)" {
+        val shape = PieceShape.TRIO_L
+        val TID = listOf("NN", "RN", "MN", "LN", "NY", "RY", "MY", "LY")
+        val SHOULD = (TID zip listOf(
+                setOf(Coordinates(0, 0), Coordinates(0, 1), Coordinates(1, 1)),
+                setOf(Coordinates(0, 0), Coordinates(0, 1), Coordinates(1, 0)),
+                setOf(Coordinates(0, 0), Coordinates(1, 0), Coordinates(1, 1)),
+                setOf(Coordinates(0, 1), Coordinates(1, 1), Coordinates(1, 0)),
+                setOf(Coordinates(0, 1), Coordinates(1, 1), Coordinates(1, 0)),
+                setOf(Coordinates(0, 0), Coordinates(1, 0), Coordinates(1, 1)),
+                setOf(Coordinates(0, 0), Coordinates(0, 1), Coordinates(1, 0)),
+                setOf(Coordinates(0, 0), Coordinates(0, 1), Coordinates(1, 1))
+        )).toMap()
+        val transformations = (TID zip (
+                (Rotation.values() zip List(Rotation.values().size) {false}) +
+                        (Rotation.values() zip List(Rotation.values().size) {true})
+                )).toMap()
+        val IS = transformations.map {
+            it.key to shape.transform(it.value.first, it.value.second)
+        }.toMap()
+        
+        TID.forEach {
+            try {
+                IS[it] shouldBe SHOULD[it]
+            } catch (e: AssertionFailedError) {
+                println("Expected:  $it  Actual:")
+                printShapes(SHOULD.getValue(it), IS.getValue(it))
+                throw e
+            }
+        }
+    }
     "Piece coordination calculation" {
         val position = Coordinates(2, 2)
         val coordinates = setOf(Coordinates(2, 3), Coordinates(3, 3), Coordinates(3, 2))
@@ -164,10 +195,32 @@ class PieceTest: StringSpec({
             val converted = Configuration.xStream.fromXML(xml) as Piece
             converted.toString() shouldBe it.toString()
             converted shouldBe it
-            println("Expected: ${it.coordinates} - Actual: ${converted.coordinates}")
         }
     }
     "Piece transformation calculation" {
-    
+        PieceShape.values().forEach {
+            it.variants shouldContain (it.coordinates to Pair(Rotation.NONE, false))
+        }
+        
+        PieceShape.MONO.variants shouldContainExactly mapOf(
+                PieceShape.MONO.coordinates to Pair(Rotation.NONE, false)
+        )
+        PieceShape.DOMINO.variants shouldContainExactly mapOf(
+                PieceShape.DOMINO.coordinates to Pair(Rotation.NONE, false),
+                PieceShape.DOMINO.transform(Rotation.RIGHT, false) to Pair(Rotation.RIGHT, false)
+        )
+        PieceShape.TRIO_L.variants.forEach {
+            println(it)
+            it.key.print()
+        }
+        PieceShape.TRIO_L.variants shouldContainExactly mapOf(
+                PieceShape.TRIO_L.coordinates to Pair(Rotation.NONE, false),
+                PieceShape.TRIO_L.transform(Rotation.NONE, true) to Pair(Rotation.NONE, true),
+                PieceShape.TRIO_L.transform(Rotation.RIGHT, false) to Pair(Rotation.RIGHT, false),
+                PieceShape.TRIO_L.transform(Rotation.RIGHT, true) to Pair(Rotation.RIGHT, true)
+        )
+        PieceShape.TETRO_O.variants shouldContainExactly mapOf(
+                PieceShape.TETRO_O.coordinates to Pair(Rotation.NONE, false)
+        )
     }
 })


### PR DESCRIPTION
Given a certain `GameState`, the `GameRuleLogic` will then calculate all possible moves.
Since only the currently active colour can perform moves, only moves from that colour will be present.

NOTE: It only returns SetMoves since they represent the majority of the game. An empty list should, ideally, never be returned because then that colour shouldn't be present in the game anymore